### PR TITLE
Cascade refresh

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/PersistentCollection.php
+++ b/lib/Doctrine/ODM/CouchDB/PersistentCollection.php
@@ -37,6 +37,13 @@ abstract class PersistentCollection implements Collection
 
     abstract protected function load();
 
+    /**
+     * INTERNAL. Gets all referenced entities, which are already loaded by
+     * the document manager, regardless of the isInitialized state of this
+     * collection. 
+     */
+    abstract public function tryGetAll(&$skip);
+
     public function changed()
     {
         return $this->changed;

--- a/lib/Doctrine/ODM/CouchDB/PersistentIdsCollection.php
+++ b/lib/Doctrine/ODM/CouchDB/PersistentIdsCollection.php
@@ -54,4 +54,23 @@ class PersistentIdsCollection extends PersistentCollection
             }
         }
     }
+
+    public function tryGetAll(&$skip)
+    {
+        if (!$this->isInitialized) {
+            $uow = $this->dm->getUnitOfWork();
+            $result = array();
+            foreach ($this->ids AS $id) {
+                if ($object = $uow->tryGetById($id)) {
+                    if (!array_key_exists(\spl_object_hash($object), $skip)) {
+                        $result[] = $object;
+                    }
+                }
+            }
+            return $result;
+        } else {
+            return $this->unwrap();
+        }
+    }
+
 }

--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -460,8 +460,7 @@ class UnitOfWork
                 $related = $class->reflFields[$assoc['fieldName']]->getValue($document);
                 if ($related instanceof Collection) {
                     if ($related instanceof PersistentCollection) {
-                        // Unwrap so that foreach() does not initialize
-                        $related = $related->unwrap();
+                        $related = $related->tryGetAll($visited);
                     }
                     foreach ($related as $relatedDocument) {
                         $this->doRefresh($relatedDocument, $visited);

--- a/tests/Doctrine/Tests/ODM/CouchDB/Functional/CascadeRefreshTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Functional/CascadeRefreshTest.php
@@ -17,6 +17,7 @@ class CascadeRefreshTest extends \Doctrine\Tests\ODM\CouchDB\CouchDBFunctionalTe
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $class->associationsMappings['groups']['cascade'] = ClassMetadata::CASCADE_REFRESH;
+        $class->associationsMappings['articles']['cascade'] = ClassMetadata::CASCADE_REFRESH;
 
         $class = $this->dm->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
         $class->associationsMappings['users']['cascade'] = ClassMetadata::CASCADE_REFRESH;
@@ -35,18 +36,26 @@ class CascadeRefreshTest extends \Doctrine\Tests\ODM\CouchDB\CouchDBFunctionalTe
         $user->name = "Benjamin";
         $user->addGroup($group1);
 
+        $article = new \Doctrine\Tests\Models\CMS\CMSArticle();
+        $article->topic = 'Test article';
+        $user->addArticle($article);
+        
         $this->dm->persist($user);
         $this->dm->persist($group1);
+        $this->dm->persist($article);
 
         $this->dm->flush();
 
         $this->assertEquals(1, count($user->groups));
 
         $group1->name = "Test2";
+        $article->topic = 'Test article2';
         $user->username = "beberlei2";
 
         $this->dm->refresh($user);
 
+        $this->assertEquals("Test article", $article->topic);
+        $this->assertEquals("beberlei", $article->user->username);
         $this->assertEquals("beberlei", $user->username);
         $this->assertEquals("Test!", $group1->name);
     }


### PR DESCRIPTION
Implemented cascade refresh. I introduced a new internal method to persistent collections, which are returning the objects could be refreshed (objects already contained by the UnitOfWork, regardless of the state of the persistent collection).
