### PR TITLE
Fix SocketClient for CouchDB 1.10

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -100,7 +100,7 @@ class SocketClient extends AbstractHTTPClient
         {
             $request .= "Content-type: application/json\r\n";
             $request .= "Content-Length: " . strlen( $data ) . "\r\n\r\n";
-            $request .= "$data\r\n";
+            $request .= "$data";
         }
         else
         {


### PR DESCRIPTION
We also use the phpillow as a CouchDB client in FLOW3 and we noticed that CouchDB 1.10 is not working correctly. I looked at the couchdb-odm and saw the same problem. Here is a small fix for the problem (at least for 1.10 - not tested against other versions).
