### PR TITLE
UnitOfWork@doDetach now uses the doc id and not the oid in identityMap.

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -653,7 +653,7 @@ class UnitOfWork
         
         switch ($this->getDocumentState($document)) {
             case self::STATE_MANAGED:
-                if (isset($this->identityMap[$oid])) {
+                if (isset($this->identityMap[$this->documentIdentifiers[$oid]])) {
                     $this->removeFromIdentityMap($document);
                 }
                 unset($this->scheduledRemovals[$oid], $this->scheduledUpdates[$oid],


### PR DESCRIPTION
In UnitOfWork@doDetach the document identifier is now used to index the document in the identityMap rather than the oid. This is consistent with the other methods in the UnitOfWork.
