### PR TITLE
Fixed Document annotation identification bug

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/MappingException.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/MappingException.php
@@ -23,6 +23,11 @@ class MappingException extends \Exception
         return new self('Class '.$className.' is not a valid document or mapped super class.');
     }
 
+    public static function classSpecifiesMultipleDocumentTypes($className)
+    {
+        return new self('Class '.$className.' may only contain one Document related class annotation.');
+    }
+
     public static function reflectionFailure($document, \ReflectionException $previousException)
     {
         return new self('An error occurred in ' . $document, 0, $previousException);


### PR DESCRIPTION
In AnnotationDriver#loadMetadataForClass() it was incorrectly assumed that an array of annotations indexed by annotation name was returned; in fact a numerically indexed array is received. This patch fixes the identification of the annotations that are present.

Since only one Document realted annotation should be present the method now also throws an exception if more than one is found. (One could just use the first annotation, but this may cause confusion when debugging.)

Not sure if this was the only outstanding problem related to issue CODM-28 but I think it was related.
