### PR TITLE
doing findMany on non-existent ids results in error

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -1239,8 +1239,8 @@ class UnitOfWork
         }
 
         $docs = array();
-        if ($response->body['total_rows'] > 0) {
-            foreach ($response->body['rows'] AS $responseData) {
+        foreach ($response->body['rows'] AS $responseData) {
+            if (isset($responseData['doc'])) {
                 $docs[$keys[$responseData['id']]] = $this->createDocument($documentName, $responseData['doc']);
             }
         }

--- a/tests/Doctrine/Tests/ODM/CouchDB/Functional/RepositoryTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Functional/RepositoryTest.php
@@ -81,6 +81,25 @@ class RepositoryTest extends \Doctrine\Tests\ODM\CouchDB\CouchDBFunctionalTestCa
         $this->assertEquals(0, count($groups), "No results, group is not indexed!");
     }
 
+    public function testLoadManyWithMissingIds()
+    {
+        $this->dm = $this->createDocumentManager();
+        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array('missing-id-1', 'missing-id-2'));
+        $this->assertEmpty($users);
+
+        $user1 = new \Doctrine\Tests\Models\CMS\CmsUser();
+        $user1->username = "beberlei";
+        $user1->status = "active";
+        $user1->name = "Benjamin";
+        $this->dm = $this->createDocumentManager();
+        $this->dm->persist($user1);
+        $this->dm->flush();
+        $this->dm->clear();
+
+        $users = $this->dm->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findMany(array($user1->id, 'missing-id-2'));
+        $this->assertEquals(1, count($users));
+    }
+
     public function testFindBy()
     {
         for ($i = 0; $i < 10; $i++) {


### PR DESCRIPTION
In the response, for the non-existent ids there is no "doc" element. This change is silently skips these.
The checking of 'total_rows' is pointless, because it is not the number of returned results (see https://issues.apache.org/jira/browse/COUCHDB-82)
