### PR TITLE
corrected @return-annotation value for getLength() method

### DIFF
--- a/lib/Doctrine/CouchDB/Attachment.php
+++ b/lib/Doctrine/CouchDB/Attachment.php
@@ -106,7 +106,7 @@ class Attachment
     /**
      * Get the length of the base64 encoded representation of this attachment.
      *
-     * @return string
+     * @return int
      */
     public function getLength()
     {


### PR DESCRIPTION
method `getLength()` returns an integer
