### PR TITLE
removed unavailable types 'array' and 'object'

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Types/Type.php
+++ b/lib/Doctrine/ODM/CouchDB/Types/Type.php
@@ -19,8 +19,6 @@ abstract class Type
     /** The map of supported doctrine mapping types. */
     private static $_typesMap = array(
         self::MIXED => 'Doctrine\ODM\CouchDB\Types\MixedType',
-        self::TARRAY => 'Doctrine\ODM\CouchDB\Types\ArrayType',
-        self::OBJECT => 'Doctrine\ODM\CouchDB\Types\ObjectType',
         self::BOOLEAN => 'Doctrine\ODM\CouchDB\Types\BooleanType',
         self::INTEGER => 'Doctrine\ODM\CouchDB\Types\IntegerType',
         self::STRING => 'Doctrine\ODM\CouchDB\Types\StringType',


### PR DESCRIPTION
their type classes does not exist and aren't necessary due to the mixed type
