### PR TITLE
DoctrineRepository view type_constraint

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/View/DoctrineRepository.php
+++ b/lib/Doctrine/ODM/CouchDB/View/DoctrineRepository.php
@@ -53,7 +53,7 @@ JS;
         $mapRepositoryTypeConstraint = <<<'JS'
 function (doc)
 {
-    if (doc.doctrine_metadata && doc.doctrine_metadata.indexed) {
+    if (doc.type) {
         emit(doc.type, {"_id": doc._id} );
     }
 }


### PR DESCRIPTION
Unless I'm missing something the DoctrineRepository view type_constraint shouldn't check for doc.doctrine_metadata (which is only present if indexes were defined) but instead look for doc.type. Before, running Repository::findAll() did not return any results; now it correctly returns all the documents of a given type.
