### PR TITLE
Update design doc command

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Tools/Console/Command/UpdateDesignDocCommand.php
+++ b/lib/Doctrine/ODM/CouchDB/Tools/Console/Command/UpdateDesignDocCommand.php
@@ -79,7 +79,7 @@ class UpdateDesignDocCommand extends Command
             return true;
         }
         foreach ($local as $key => $val) {
-            if ($remote[$key] != $val) {
+            if (!isset($remote[$key]) || $remote[$key] != $val) {
                 return true;
             }
             unset($remote[$key]);


### PR DESCRIPTION
The check for differences in the local and remote design docs in _couchdb:odm:update-design-doc_ command did not work for non-view design docs. This has been fixed and tested using a doc with views and one with only a _validate_doc_update_ key.
