### PR TITLE
MetadataCache was never set

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
@@ -69,7 +69,9 @@ class ClassMetadataFactory implements \Doctrine\Common\Persistence\Mapping\Class
     public function __construct(DocumentManager $dm)
     {
         $this->dm = $dm;
-        $this->driver = $this->dm->getConfiguration()->getMetadataDriverImpl();
+        $config = $this->dm->getConfiguration();
+        $this->driver = $config->getMetadataDriverImpl();
+        $this->cacheDriver = $config->getMetadataCacheImpl();
         if (!$this->driver) {
             throw new \RuntimeException("No metadata driver was configured.");
         }


### PR DESCRIPTION
The MetadataCache was never set in the ClassMetadataFactory and thus no caching was ever performed. I have set the _cacheDriver_ in the ClassMetadataFactory constructor similar to the _driver_ using the dm configuration. Metadata caching now works correctly.
