### PR TITLE
CouchDBException::assignedIdGeneratorNoIdFound should use $className

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/CouchDBException.php
+++ b/lib/Doctrine/ODM/CouchDB/CouchDBException.php
@@ -64,7 +64,8 @@ class CouchDBException extends \Exception
 
     public static function assignedIdGeneratorNoIdFound($className)
     {
-        return new self("Document has assigned id generator configured, however no ID was found during persist().");
+        return new self("Document $className has assigned id generator configured, " .
+            "however no ID was found during persist().");
     }
 }
 


### PR DESCRIPTION
Classname is passed for CouchDBException::assignedIdGeneratorNoIdFound($className) but ignored.

When working with many document classes and deferred  flush() it is hard to debug which class caused the exception.
