### PR TITLE
Testing document type in UnitOfWork::doMerge

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/CouchDBException.php
+++ b/lib/Doctrine/ODM/CouchDB/CouchDBException.php
@@ -66,5 +66,10 @@ class CouchDBException extends \Exception
     {
         return new self("Document has assigned id generator configured, however no ID was found during persist().");
     }
-}
 
+    public static function unexpectedDocumentType($document)
+    {
+        $type = gettype($document);
+        return new self("Document was expected to be an object. $type given instead.");
+    }
+}

--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -447,6 +447,10 @@ class UnitOfWork
 
     private function doMerge($document, array &$visited, $prevManagedCopy = null, $assoc = null)
     {
+        if (!is_object($document)) {
+            throw CouchDBException::unexpectedDocumentType($document);
+        }
+
         $oid = spl_object_hash($document);
         if (isset($visited[$oid])) {
             return; // Prevent infinite recursion


### PR DESCRIPTION
UnitOfWork::doMerge() may be called with an array for $document when cascading documents.

Not entirely sure if only the annotation was not up to date, but it is good to test your input data to avoid unspecific warnings/ errors if something breaks.

Do you need a quick review for other methods?

I may provide a good set of parameter checks and method descriptions. 
