### PR TITLE
DriverChain should use doctrine common MappingDriverChain.

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/Driver/DriverChain.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ODM\CouchDB\Mapping\Driver;
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+
 /**
  * The DriverChain allows you to add multiple other mapping drivers for
  * certain namespaces


### PR DESCRIPTION
There was an issue during installation of DoctrineCouchDBBundle that the class MappingDriverChain was not found. I assume that this should be the MappingDriverChain from doctrine/common.
