### PR TITLE
Throw an error when the identifier field is not available

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
@@ -83,6 +83,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($this->getDriver()) {
             $this->getDriver()->loadMetadataForClass($class->getName(), $class);
         }
+        $class->checkUp();
     }
 
     /**

--- a/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataInfo.php
@@ -247,6 +247,15 @@ class ClassMetadataInfo
     }
 
     /**
+     * Check for any possible shortcomings in the class
+     */
+    public function checkUp() {
+        if (!isset($this->identifier)) {
+            throw new MappingException('An identifier field is required.');
+        }
+    }    
+
+    /**
      * Get identifier field names of this class.
      *
      * Since CouchDB only allows exactly one identifier field this is a proxy


### PR DESCRIPTION
I accidentally mapped an empty class, then I got 2 errors: "Undefined index: in ...Doctrine/ODM/CouchDB/Mapping/ClassMetadata.php", "Fatal error: Call to a member function getValue() on a non-object in .../Doctrine/ODM/CouchDB/Mapping/ClassMetadata.php".
the erroring part is `reflFields[$this->identifier]`.
The reason is, there's no id field, it's a bit confusing and it wastes new user's time.
So there should be an error message.
