### PR TITLE
Fix Pull #62 error: ClassMetadataInfo::checkUp() - Embedded documents shouldn't have an id.

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataInfo.php
@@ -247,11 +247,14 @@ class ClassMetadataInfo
     }
 
     /**
-     * Check for any possible shortcomings in the class
+     * Check for any possible shortcomings in the class:
+     * 
+     *  - The class must have an identifier field unless it's an embedded document.
+     * 
      */
     public function checkUp() {
-        if (!isset($this->identifier)) {
-            throw new MappingException('An identifier field is required.');
+        if (!isset($this->identifier) && !$this->isEmbeddedDocument) {
+            throw new MappingException("An identifier (@Id) field is required in {$this->getName()}.");
         }
     }    
 


### PR DESCRIPTION
The `ClassMetadataInfo:checkUp()` method added in Pull #62 checked for the presence of an identifier but didn't exempt embedded documents.

The comment of this method is now more specific and ready to be extended with the details of additional future checks.

The exception message indicates that _identifier_ refers to the _@Id_ field since this wasn't immediately apparent, and the name of the class producing the error is also included.
