### PR TITLE
Mapped super-class indexed fields issue

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/ClassMetadataFactory.php
@@ -96,6 +96,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         foreach ($parent->fieldMappings as $name => $field) {
             $class->fieldMappings[$name] = $field;
+            
+            if (array_key_exists('indexed', $field) && $field['indexed']) {
+                $class->indexes[] = $field['fieldName'];
+            }
         }
 
         foreach ($parent->jsonNames as $name => $field) {


### PR DESCRIPTION
I'm new in Symfony, I was working around with FOSUserBundle and it was first time that I used an extended class (my User document) from super-class FOS\UserBundle\Model\User, with XML mapped fields ...

Indexed fields in super-class are not mapped to child class, so search functionality was broken and FOS couldn't find any user with indexed fields ...

As couchdb-odm-bundle is not getting new updates anymore and I needed new symfony core updates, I commented couchdb-odm and couchdb-odm-bundle from composer, so, I'm including them manually ...

I don't know exactly if it got fixed already or not, I fixed my problem myself :P
