### PR TITLE
Minor clean-up of the DocumentRepository

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/DocumentRepository.php
+++ b/lib/Doctrine/ODM/CouchDB/DocumentRepository.php
@@ -140,21 +140,17 @@ class DocumentRepository implements ObjectRepository
             }
         } else {
             $ids = array();
-            $num = 0;
             foreach ($criteria AS $field => $value) {
-                $ids[$num] = array();
+                $critIds = array();
+                $ids[] = &$critIds;
                 $result = $this->dm->createNativeQuery('doctrine_repositories', 'equal_constraint')
                                    ->setKey(array($this->documentType, $field, $value))
                                    ->execute();
-                foreach ($result aS $doc) {
-                    $ids[$num][] = $doc['id'];
+                foreach ($result AS $doc) {
+                    $critIds[] = $doc['id'];
                 }
-                $num++;
             }
-            $mergeIds = $ids[0];
-            for ($i = 1; $i < $num; $i++) {
-                $mergeIds = array_intersect($mergeIds, $ids[$i]);
-            }
+            $mergeIds = call_user_func_array('array_intersect', $ids);
 
             return $this->findMany(array_values($mergeIds), $limit, $offset);
         }


### PR DESCRIPTION
None of these changes are essential, but I spotted room for improvement (in my opinion) when was looking through the repository code. Each commit has a single change in decreasing order of importance:
1. In `findAll()` it is more efficient to return the array directly from the query object rather than looping through the result after the fact.
2. Avoid an unnecessary function call in a small number of cases (changed on principle).
3. Since the `$ids` array has the proper format for calling `array_intersect` directly using `call_user_func_array` the use of a _for-loop_ seemed superfluous.
