### PR TITLE
Added __call to the DocumentRepository for magic finders.

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/CouchDBException.php
+++ b/lib/Doctrine/ODM/CouchDB/CouchDBException.php
@@ -57,6 +57,19 @@ class CouchDBException extends \Exception
         return new self("Trying to persist document that is scheduled for removal.");
     }
 
+    public static function findByRequiresParameter($methodName)
+    {
+        return new self("You need to pass a parameter to '".$methodName."'");
+    }
+
+    public static function invalidFindByCall($documentName, $fieldName, $method)
+    {
+        return new self(
+            "Document '".$documentName."' has no field '".$fieldName."'. ".
+            "You can therefore not call '".$method."' on the documents' repository."
+        );
+    }
+
     public static function luceneNotConfigured()
     {
         return  new self("CouchDB Lucene is not configured. You have to configure the handler name to enable support for Lucene Queries.");


### PR DESCRIPTION
The use of magic finders, e.g. `$repo->findOneByNickname('romanb')`, is discussed in the [CouchDb ODM documentation](http://docs.doctrine-project.org/projects/doctrine-couchdb/en/latest/reference/working-with-objects.html#by-simple-conditions), but it seems it was never implemented.

I adapted this implementation from the [Doctrine 2 ORM](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityRepository.php). The only major change is using `call_user_func_array` to finally call the `find(One)By` method with the full arguments list rather than using a switch for each number of possible arguments.