### PR TITLE
update dependeny to doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.2.0,<2.4",
+        "doctrine/common": "~2.2",
         "doctrine/couchdb": "dev-master",
         "symfony/console": ">=2.0"
     },


### PR DESCRIPTION
There is no error with the current 2.4 release of doctrine/common. So it can be used.
