### PR TITLE
Event fixes

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ODM/CouchDB/Event/LifecycleEventArgs.php
@@ -20,24 +20,15 @@
 
 namespace Doctrine\ODM\CouchDB\Event;
 
-class LifecycleEventArgs extends \Doctrine\Common\EventArgs
+class LifecycleEventArgs extends \Doctrine\Common\Persistence\Event\LifecycleEventArgs
 {
-    private $document;
-
-    private $documentManager;
-
-    function __construct($document, $documentManager)
-    {
-        $this->document = $document;
-        $this->documentManager = $documentManager;
-    }
 
     /**
      * @return object
      */
     public function getDocument()
     {
-        return $this->document;
+        return $this->getObject();
     }
 
     /**
@@ -45,6 +36,6 @@ class LifecycleEventArgs extends \Doctrine\Common\EventArgs
      */
     public function getDocumentManager()
     {
-        return $this->documentManager;
+        return $this->getObjectManager();
     }
 }

--- a/lib/Doctrine/ODM/CouchDB/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ODM/CouchDB/Event/OnFlushEventArgs.php
@@ -20,20 +20,13 @@
 
 namespace Doctrine\ODM\CouchDB\Event;
 
-class OnFlushEventArgs extends \Doctrine\Common\EventArgs
+class OnFlushEventArgs extends \Doctrine\Common\Persistence\Event\ManagerEventArgs
 {
-    private $documentManager;
-
-    public function __construct($documentManager)
-    {
-        $this->documentManager = $documentManager;
-    }
-
     /**
      * @return \Doctrine\ODM\CouchDB\DocumentManager
      */
     public function getDocumentManager()
     {
-        return $this->documentManager;
+        return $this->getObjectManager();
     }
 }

--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -1016,7 +1016,7 @@ class UnitOfWork
         $this->detectChangedDocuments();
 
         if ($this->evm->hasListeners(Event::onFlush)) {
-            $this->evm->dispatchEvent(Event::onFlush, new Event\OnFlushEventArgs($this));
+            $this->evm->dispatchEvent(Event::onFlush, new Event\OnFlushEventArgs($this->dm));
         }
 
         $config = $this->dm->getConfiguration();


### PR DESCRIPTION
This will fix a bug that unitOfWork uses wrong parameter for onFlushEventArgs and adds usage of \Doctrine\Common\Persistence\Event base classes
