### PR TITLE
Proposed fix for associated objects always fetched from database (Issue #93)

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/MetadataResolver/DoctrineResolver.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/MetadataResolver/DoctrineResolver.php
@@ -61,7 +61,7 @@ class DoctrineResolver implements MetadataResolver
                     if ($class->associationsMappings[$assocName]['type'] & ClassMetadata::TO_ONE) {
                         if ($assocValue) {
                             if ($class->associationsMappings[$assocName]['targetDocument'] &&
-                                ! $dm->getClassMetadata($class->associationsMappings[$assocName]['targetDocument'])->inInheritanceHierachy) {
+                                $dm->getClassMetadata($class->associationsMappings[$assocName]['targetDocument'])->inInheritanceHierachy) {
 
                                 $assocValue = $dm->getReference($class->associationsMappings[$assocName]['targetDocument'], $assocValue);
                             } else {


### PR DESCRIPTION
When checking if an associated object is already in the inheritance hierarchy, the condition returned false if the object was found while it should return true
