### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.3.2",
         "doctrine/common": "~2.2",
         "doctrine/couchdb": "dev-master",
-        "symfony/console": ">=2.0"
+        "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.0",


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0