### PR TITLE
Xml version mapping

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
@@ -112,6 +112,16 @@ class XmlDriver extends FileDriver
             ));
         }
 
+        // Evaluate <version ..> mappings
+        foreach ($xmlRoot->version as $versionElement) {
+            $class->mapField(array(
+                'fieldName'      => (string)$versionElement['name'],
+                'type'           => 'string',
+                'isVersionField' => true,
+                'jsonName'       => '_rev',
+            ));
+        }
+
         // Evaluate <many-to-one ..> mappings
         if (isset($xmlRoot->{"reference-one"})) {
             foreach ($xmlRoot->{"reference-one"} as $referenceOneElement) {

--- a/tests/Doctrine/Tests/ODM/CouchDB/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Mapping/AbstractMappingDriverTest.php
@@ -131,4 +131,21 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
             'type' => 'mixed',
         ), $class->fieldMappings['address']);
     }
+
+    public function testVersionMapping()
+    {
+        $className = 'Doctrine\Tests\Models\CMS\CmsArticle';
+        $mappingDriver = $this->loadDriver();
+
+        $class = new ClassMetadata($className);
+        $class->namespace = 'Doctrine\Tests\Models\CMS';
+        $mappingDriver->loadMetadataForClass($className, $class);
+
+        $this->assertEquals(array(
+            'fieldName' => 'version',
+            'jsonName' => '_rev',
+            'type' => 'string',
+            'isVersionField' => true,
+        ), $class->fieldMappings['version']);
+    }
 }

--- a/tests/Doctrine/Tests/ODM/CouchDB/Mapping/xml/Doctrine.Tests.Models.CMS.CmsArticle.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Mapping/xml/Doctrine.Tests.Models.CMS.CmsArticle.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+    <document name="Doctrine\Tests\Models\CMS\CmsArticle" index="true">
+        <id name="id" />
+        <!--
+            As an alternative for:
+            <field name="version" version="true" type="string" json-name="_rev" />
+        -->
+        <version name="version" />
+
+        <field name="topic" type="string" index="true" />
+        <field name="text" type="string" index="true" />
+        <field name="name" type="string" index="true" />
+        
+        <reference-one field="user" target-document="CmsUser" />
+        
+        <attachments field="attachments" />
+    </document>
+</doctrine-mapping>


### PR DESCRIPTION
To create a properly working field with the documents revision, when using XML mapping files, one has to use:

```
<field name="version" version="true" type="string" json-name="_rev" />
```

Especially the requirement of specifying the json-name manually imho requires too much internal knowledge. If not specifying the json-name attribute the revision will be set on write, but not on any read later, which is hard to debug as well.

With this PR one can specify version fields like:

```
<version name="version" />
```