### PR TITLE
Fixed autoloading for console tools

### DIFF
--- a/bin/doctrine-couchdb.php
+++ b/bin/doctrine-couchdb.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-require_once 'Doctrine/Common/ClassLoader.php';
+(@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
 
 $classLoader = new \Doctrine\Common\ClassLoader('Doctrine');
 $classLoader->register();


### PR DESCRIPTION
The autoloading does not work when installed via composer
I took the same approach as the doctrine-orm console tools.
