### PR TITLE
Increased minimum php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         {"name": "Lukas Kahwe Smith", "email": "smith@pooteeweet.org"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "doctrine/common": "~2.2",
         "doctrine/couchdb": "dev-master",
         "symfony/console": ">=2.0",


### PR DESCRIPTION
Good Evening,
Right now `doctrine/couchdb` requires a version of php >= 5.4.  This change increases the minimum to match.