### PR TITLE
Added urlencode to filename for attachments

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
+++ b/lib/Doctrine/ODM/CouchDB/UnitOfWork.php
@@ -291,7 +291,7 @@ class UnitOfWork
         $basePath = '/' . $this->dm->getCouchDBClient()->getDatabase() . '/' . $documentId . '/';
         foreach ($data AS $filename => $attachment) {
             if (isset($attachment['stub']) && $attachment['stub']) {
-                $instance = Attachment::createStub($attachment['content_type'], $attachment['length'], $attachment['revpos'], $client, $basePath . $filename);
+                $instance = Attachment::createStub($attachment['content_type'], $attachment['length'], $attachment['revpos'], $client, $basePath . urlencode($filename));
             } else if (isset($attachment['data'])) {
                 $instance = Attachment::createFromBase64Data($attachment['data'], $attachment['content_type'], $attachment['revpos']);
             }

--- a/tests/Doctrine/Tests/ODM/CouchDB/Functional/AttachmentTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Functional/AttachmentTest.php
@@ -16,6 +16,15 @@ class AttachmentTest extends \Doctrine\Tests\ODM\CouchDB\CouchDBFunctionalTestCa
         $this->dm = $this->createDocumentManager();
         $client = $this->dm->getHttpClient();
         $response = $client->request('PUT', '/' . $this->getTestDatabase() . '/user_with_attachment', \file_get_contents(__DIR__ . "/_files/user_with_attachment.json"));
+        $response = $client->request('PUT', '/' . $this->getTestDatabase() . '/attachment_with_spaces_in_name', \file_get_contents(__DIR__ . "/_files/attachment_with_spaces_in_name.json"));
+    }
+
+    public function testGetAttachmentWithSpacesInName()
+    {
+        $user = $this->dm->find('Doctrine\Tests\Models\CMS\CmsUser', 'attachment_with_spaces_in_name');
+        $this->assertArrayHasKey('attachment with spaces.txt', $user->attachments);
+        $this->assertInstanceOf('Doctrine\CouchDB\Attachment', $user->attachments['attachment with spaces.txt']);
+        $this->assertEquals('This is a base64 encoded text', $user->attachments['attachment with spaces.txt']->getRawData());
     }
 
     public function testHydrateAttachments()

--- a/tests/Doctrine/Tests/ODM/CouchDB/Functional/_files/attachment_with_spaces_in_name.json
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Functional/_files/attachment_with_spaces_in_name.json
@@ -1,0 +1,12 @@
+{
+   "_id": "attachment_with_spaces_in_name",
+   "_attachments":
+   {
+        "attachment with spaces.txt":
+        {
+            "content_type":"text\/plain",
+            "data": "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHRleHQ="
+        }
+    },
+    "type": "Doctrine.Tests.Models.CMS.CmsUser"
+}


### PR DESCRIPTION
Encoding the filename makes it possible to get attachments with spaces.