### PR TITLE
serialize embedded document with references associations

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/EmbeddedDocumentSerializer.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/EmbeddedDocumentSerializer.php
@@ -85,7 +85,40 @@ class EmbeddedDocumentSerializer
             $data = $this->metadataResolver->createDefaultDocumentStruct($embeddedClass);
             foreach($embeddedClass->reflFields AS $fieldName => $reflProperty) {
                 $value = $reflProperty->getValue($embeddedValue);
-                $fieldMapping = $embeddedClass->fieldMappings[$fieldName];
+                
+                if (isset($fieldName, $embeddedClass->fieldMappings[$fieldName])) {
+                    $fieldMapping = $embeddedClass->fieldMappings[$fieldName];
+                } elseif (isset($embeddedClass->associationsMappings, $embeddedClass->associationsMappings[$fieldName])) {
+                    /** @see UnitOfWork::flush() */
+                    if ($embeddedClass->associationsMappings[$fieldName]['type'] & ClassMetadata::TO_ONE) {
+                        $fieldValue = null;
+                        if (\is_object($value)) {
+                            $fieldValueMetadata = $this->metadataFactory->getMetadataFor(get_class($value));
+                            $fieldValue = $fieldValueMetadata->getIdentifierValue($value);
+                        }
+                        $data['doctrine_metadata']['associations'][] = $fieldName;
+                        $data[$fieldName] = $fieldValue;
+                    } else if ($embeddedClass->associationsMappings[$fieldName]['type'] & ClassMetadata::TO_MANY) {
+
+                        if ($embeddedClass->associationsMappings[$fieldName]['isOwning']) {
+                            // TODO: Optimize when not initialized yet! In ManyToMany case we can keep track of ALL ids
+                            $ids = array();
+                            if (is_array($value) || $value instanceof \Doctrine\Common\Collections\Collection) {
+                                foreach ($value AS $key => $relatedObject) {
+                                    $fieldValueMetadata = $this->metadataFactory->getMetadataFor(get_class($relatedObject));
+                                    $ids[$key] = $fieldValueMetadata->getIdentifierValue($relatedObject);
+                                }
+                            }
+
+                            $data['doctrine_metadata']['associations'][] = $ids;
+                            $data[$fieldName] = $ids;
+                        }
+                    }
+
+                    continue;
+                } else {
+                    $fieldMapping = [];
+                }
 
                 if ($value === null) {
                     continue;
@@ -97,6 +130,7 @@ class EmbeddedDocumentSerializer
                 }
             }
         }
+        
         return $data;
     }
 


### PR DESCRIPTION
Hello,

I had to load my fixtures with some EmbeddedDocument with Associations but I could not.
So, I edited `EmbeddedDocumentSerializer` to fix that problem. But, I duplicated some code from `UnitOfWork::flush()` and `DoctrineResolver::storeAssociationField()`, so if someone could refactor this, it will be pretty cool. ;)

Thanks.
