### PR TITLE
Fixed empty "target-document" behavior for XmlDriver

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
@@ -140,7 +140,7 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'embed-one'})) {
             foreach ($xmlRoot->{'embed-one'} AS $embedOneElement) {
                 $class->mapEmbedded(array(
-                    'targetDocument'    => (string)$embedOneElement['target-document'],
+                    'targetDocument'    => (isset($embedOneElement['target-document']) ? (string)$embedOneElement['target-document'] : null),
                     'fieldName'         => (string)$embedOneElement['field'],
                     'jsonName'          => (isset($embedOneElement['json-name'])) ? (string)$embedOneElement['json-name'] : null,
                     'embedded'          => 'one',

--- a/tests/Doctrine/Tests/ODM/CouchDB/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Mapping/AbstractMappingDriverTest.php
@@ -127,7 +127,7 @@ abstract class AbstractMappingDriverTest extends \PHPUnit_Framework_TestCase
             'fieldName' => 'address',
             'jsonName' => 'address',
             'embedded' => 'one',
-            'targetDocument' => '',
+            'targetDocument' => null,
             'type' => 'mixed',
         ), $class->fieldMappings['address']);
     }


### PR DESCRIPTION
The XmlDriver by now casts the "target-document" attribute to string regardless of if it is set or not. This results in the EmbeddedDocumentSerializer to try to look up an empty class. See:

https://github.com/doctrine/couchdb-odm/blob/master/lib/Doctrine/ODM/CouchDB/Mapping/EmbeddedDocumentSerializer.php#L53

This PR provides  fix.