### PR TITLE
Fix XML mapping of <embed-many/> without target-document

### DIFF
--- a/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ODM/CouchDB/Mapping/Driver/XmlDriver.php
@@ -152,7 +152,7 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'embed-many'})) {
             foreach ($xmlRoot->{'embed-many'} AS $embedManyElement) {
                 $class->mapEmbedded(array(
-                    'targetDocument'    => (string)$embedManyElement['target-document'],
+                    'targetDocument'    => (isset($embedManyElement['target-document']) ? (string)$embedManyElement['target-document'] : null),
                     'fieldName'         => (string)$embedManyElement['field'],
                     'jsonName'          => (isset($embedManyElement['json-name'])) ? (string)$embedManyElement['json-name'] : null,
                     'embedded'          => 'many',

--- a/tests/Doctrine/Tests/ODM/CouchDB/Mapping/XmlDriverTest.php
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Mapping/XmlDriverTest.php
@@ -11,4 +11,21 @@ class XmlDriverTest extends AbstractMappingDriverTest
     {
         return new XmlDriver(array(__DIR__."/xml"));
     }
+
+    public function testEmbedManyWithoutTargetDocuments()
+    {
+        $className = 'Doctrine\Tests\XML\EmbedMany';
+        $mappingDriver = $this->loadDriver();
+
+        $class = new ClassMetadata($className);
+        $class->namespace = 'Doctrine\Tests\XML';
+        $mappingDriver->loadMetadataForClass($className, $class);
+
+        $this->assertTrue(isset($class->fieldMappings['embeddedField']));
+        $this->assertArrayHasKey(
+            'targetDocument',
+            $class->fieldMappings['embeddedField']
+        );
+        $this->assertNull($class->fieldMappings['embeddedField']['targetDocument']);
+    }
 }

--- a/tests/Doctrine/Tests/ODM/CouchDB/Mapping/xml/Doctrine.Tests.XML.EmbedMany.dcm.xml
+++ b/tests/Doctrine/Tests/ODM/CouchDB/Mapping/xml/Doctrine.Tests.XML.EmbedMany.dcm.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+    <document name="Doctrine\Tests\XML\EmbedMany" index="true">
+        <id name="id" />
+        <embed-many field="embeddedField" />
+    </document>
+</doctrine-mapping>


### PR DESCRIPTION
Same fix as for <embed/> but with an additional test because there was none.